### PR TITLE
Corrige el día del trabajo

### DIFF
--- a/mexican-holidays.el
+++ b/mexican-holidays.el
@@ -38,7 +38,7 @@
   '((holiday-fixed 1 1 "Año Nuevo")
     (holiday-fixed 2 5 "Día de la Constitución")
     (holiday-fixed 3 21 "Natalicio de Benito Juárez")
-    (holiday-fixed 4 1 "Día del Trabajo")
+    (holiday-fixed 5 1 "Día del Trabajo")
     (holiday-fixed 9 16 "Día de la Independencia de México")
     (holiday-fixed 11 20 "Día de la Revolución Mexicana")
     (holiday-fixed 12 25 "Navidad")


### PR DESCRIPTION
El Día del Trabajo es el 1 de mayo, no el 1 de abril.